### PR TITLE
fix(k8s): Add missing securityContext configuration

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -28,6 +28,13 @@ spec:
             cpu: 5m
             memory: 64Mi
         imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -47,6 +47,11 @@ spec:
               key: CHECKLY_ACCOUNT_ID
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Much needed k8s resource security configuration for the operator. This
will help many organisations with utilizing the operator as we are
disabling so many write/privilege access.

Tested successfully locally.