### PR TITLE
feat(tags): Turn all labels into tags

### DIFF
--- a/config/samples/checkly_v1alpha1_apicheck.yaml
+++ b/config/samples/checkly_v1alpha1_apicheck.yaml
@@ -2,10 +2,11 @@ apiVersion: k8s.checklyhq.com/v1alpha1
 kind: ApiCheck
 metadata:
   name: apicheck-sample
+  labels:
+    service: "foo"
 spec:
   endpoint: "https://foo.bar/baz"
   success: "200"
-  team: qux
   frequency: 10 # Default 5
   muted: true # Default "false"
   group: "group-sample"

--- a/config/samples/checkly_v1alpha1_group.yaml
+++ b/config/samples/checkly_v1alpha1_group.yaml
@@ -2,6 +2,8 @@ apiVersion: k8s.checklyhq.com/v1alpha1
 kind: Group
 metadata:
   name: group-sample
+  labels:
+    environment: "local"
 spec:
   locations:
     - eu-west-1

--- a/controllers/checkly/apicheck_controller.go
+++ b/controllers/checkly/apicheck_controller.go
@@ -145,6 +145,7 @@ func (r *ApiCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		ID:              apiCheck.Status.ID,
 		GroupID:         group.Status.ID,
 		Muted:           apiCheck.Spec.Muted,
+		Labels:          apiCheck.Labels,
 	}
 
 	// /////////////////////////////

--- a/controllers/checkly/group_controller.go
+++ b/controllers/checkly/group_controller.go
@@ -119,6 +119,7 @@ func (r *GroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		Locations:     group.Spec.Locations,
 		AlertChannels: group.Spec.AlertChannels,
 		ID:            group.Status.ID,
+		Labels:        group.Labels,
 	}
 
 	// /////////////////////////////

--- a/external/checkly/api_common.go
+++ b/external/checkly/api_common.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package external
 
+import "fmt"
+
 func checkValueString(x string, y string) (value string) {
 	if x == "" {
 		value = y
@@ -40,5 +42,14 @@ func checkValueArray(x []string, y []string) (value []string) {
 	} else {
 		value = x
 	}
+	return
+}
+
+func getTags(labels map[string]string) (tags []string) {
+
+	for k, v := range labels {
+		tags = append(tags, fmt.Sprintf("%s:%s", k, v))
+	}
+
 	return
 }

--- a/external/checkly/api_common_test.go
+++ b/external/checkly/api_common_test.go
@@ -76,3 +76,20 @@ func TestCheckValueArray(t *testing.T) {
 	}
 
 }
+
+func TestGetTags(t *testing.T) {
+	var data = make(map[string]string)
+	data["foo"] = "bar"
+
+	response := getTags(data)
+	if len(response) != 1 {
+		t.Errorf("Expected 1 item, got %d", len(response))
+	}
+
+	for _, v := range response {
+		if v != "foo:bar" {
+			t.Errorf("Expected foo:bar, got %s", v)
+		}
+	}
+
+}

--- a/external/checkly/check.go
+++ b/external/checkly/check.go
@@ -36,6 +36,7 @@ type Check struct {
 	GroupID         int64
 	ID              string
 	Muted           bool
+	Labels          map[string]string
 }
 
 func checklyCheck(apiCheck Check) (check checkly.Check, err error) {
@@ -44,6 +45,10 @@ func checklyCheck(apiCheck Check) (check checkly.Check, err error) {
 	if err != nil {
 		return
 	}
+
+	tags := getTags(apiCheck.Labels)
+	tags = append(tags, "checkly-operator")
+	tags = append(tags, apiCheck.Namespace)
 
 	alertSettings := checkly.AlertSettings{
 		EscalationType: checkly.RunBased,
@@ -63,23 +68,20 @@ func checklyCheck(apiCheck Check) (check checkly.Check, err error) {
 	}
 
 	check = checkly.Check{
-		Name:                 apiCheck.Name,
-		Type:                 checkly.TypeAPI,
-		Frequency:            checkValueInt(apiCheck.Frequency, 5),
-		DegradedResponseTime: 5000,
-		MaxResponseTime:      checkValueInt(apiCheck.MaxResponseTime, 15000),
-		Activated:            true,
-		Muted:                apiCheck.Muted, // muted for development
-		ShouldFail:           shouldFail,
-		DoubleCheck:          false,
-		SSLCheck:             false,
-		LocalSetupScript:     "",
-		LocalTearDownScript:  "",
-		Locations:            []string{},
-		Tags: []string{
-			apiCheck.Namespace,
-			"checkly-operator",
-		},
+		Name:                   apiCheck.Name,
+		Type:                   checkly.TypeAPI,
+		Frequency:              checkValueInt(apiCheck.Frequency, 5),
+		DegradedResponseTime:   5000,
+		MaxResponseTime:        checkValueInt(apiCheck.MaxResponseTime, 15000),
+		Activated:              true,
+		Muted:                  apiCheck.Muted, // muted for development
+		ShouldFail:             shouldFail,
+		DoubleCheck:            false,
+		SSLCheck:               false,
+		LocalSetupScript:       "",
+		LocalTearDownScript:    "",
+		Locations:              []string{},
+		Tags:                   tags,
 		AlertSettings:          alertSettings,
 		UseGlobalAlertSettings: false,
 		GroupID:                apiCheck.GroupID,

--- a/external/checkly/group.go
+++ b/external/checkly/group.go
@@ -30,9 +30,14 @@ type Group struct {
 	Locations     []string
 	Activated     bool
 	AlertChannels []string
+	Labels        map[string]string
 }
 
 func checklyGroup(group Group) (check checkly.Group) {
+
+	tags := getTags(group.Labels)
+	tags = append(tags, "checkly-operator")
+	tags = append(tags, group.Namespace)
 
 	alertSettings := checkly.AlertSettings{
 		EscalationType: checkly.RunBased,
@@ -52,18 +57,15 @@ func checklyGroup(group Group) (check checkly.Group) {
 	}
 
 	check = checkly.Group{
-		Name:                group.Name,
-		Activated:           true,
-		Muted:               false, // muted for development
-		DoubleCheck:         false,
-		LocalSetupScript:    "",
-		LocalTearDownScript: "",
-		Concurrency:         2,
-		Locations:           checkValueArray(group.Locations, []string{"eu-west-1"}),
-		Tags: []string{
-			group.Namespace,
-			"checkly-operator",
-		},
+		Name:                      group.Name,
+		Activated:                 true,
+		Muted:                     false, // muted for development
+		DoubleCheck:               false,
+		LocalSetupScript:          "",
+		LocalTearDownScript:       "",
+		Concurrency:               2,
+		Locations:                 checkValueArray(group.Locations, []string{"eu-west-1"}),
+		Tags:                      tags,
 		AlertSettings:             alertSettings,
 		UseGlobalAlertSettings:    false,
 		AlertChannelSubscriptions: []checkly.AlertChannelSubscription{},


### PR DESCRIPTION
In kubernetes we can apply labels to each resource, this can hold any
key/value pair, just like the tags in checkly checks. Using the new
feature from checklyhq.com where all tags become labels in the
prometheus endpoint, we can actually set tags from the labels of the
checks and groups which we set up.