### PR TITLE
fix(groups): Add group namespace field

### DIFF
--- a/apis/checkly/v1alpha1/apicheck_types.go
+++ b/apis/checkly/v1alpha1/apicheck_types.go
@@ -45,6 +45,9 @@ type ApiCheckSpec struct {
 
 	// Group determines in which group does the check belong to
 	Group string `json:"group"`
+
+	// GroupNamespace determine in which namespace was the group defined
+	GroupNamespace string `json:"groupnamespace,omitempty"`
 }
 
 // ApiCheckStatus defines the observed state of ApiCheck

--- a/config/crd/bases/k8s.checklyhq.com_apichecks.yaml
+++ b/config/crd/bases/k8s.checklyhq.com_apichecks.yaml
@@ -64,6 +64,10 @@ spec:
                 description: Group determines in which group does the check belong
                   to
                 type: string
+              groupnamespace:
+                description: GroupNamespace determine in which namespace was the group
+                  defined
+                type: string
               maxresponsetime:
                 description: MaxResponseTime determines what the maximum number of
                   miliseconds can pass before the check fails, default 15000

--- a/config/samples/checkly_v1alpha1_apicheck.yaml
+++ b/config/samples/checkly_v1alpha1_apicheck.yaml
@@ -10,3 +10,4 @@ spec:
   frequency: 10 # Default 5
   muted: true # Default "false"
   group: "group-sample"
+  groupnamespace: "default" # If not specified, the controller assumes the group is in the same namespace 

--- a/controllers/checkly/apicheck_controller.go
+++ b/controllers/checkly/apicheck_controller.go
@@ -117,7 +117,13 @@ func (r *ApiCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Lookup group ID
 	// ////////////////////////////
 	group := &checklyv1alpha1.Group{}
-	err = r.Get(ctx, types.NamespacedName{Name: apiCheck.Spec.Group, Namespace: apiCheck.Namespace}, group)
+	var groupNamespace string
+	if apiCheck.Spec.GroupNamespace == "" {
+		groupNamespace = apiCheck.Namespace
+	} else {
+		groupNamespace = apiCheck.Spec.GroupNamespace
+	}
+	err = r.Get(ctx, types.NamespacedName{Name: apiCheck.Spec.Group, Namespace: groupNamespace}, group)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// The resource has been deleted

--- a/controllers/checkly/apicheck_controller_test.go
+++ b/controllers/checkly/apicheck_controller_test.go
@@ -126,8 +126,35 @@ var _ = Describe("ApiCheck Controller", func() {
 				}
 			}, timeout, interval).Should(BeTrue())
 
+			// Update
+			groupUpdateNS := "kube-system"
+			groupUpdate := &checklyv1alpha1.Group{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      groupKey.Name,
+					Namespace: groupUpdateNS,
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), groupUpdate)).Should(Succeed())
+
+			apiCheckRaw := &checklyv1alpha1.ApiCheck{}
+			Expect(k8sClient.Get(context.Background(), key, apiCheckRaw)).Should(Succeed())
+			apiCheckRaw.Spec.GroupNamespace = groupUpdateNS
+			Expect(k8sClient.Update(context.Background(), apiCheckRaw)).Should(Succeed())
+
+			By("Expecting groupnamespace to change")
+			Eventually(func() bool {
+				f := &checklyv1alpha1.ApiCheck{}
+				err := k8sClient.Get(context.Background(), key, f)
+				if err == nil && f.Spec.GroupNamespace == groupUpdateNS {
+					return true
+				}
+				return false
+
+			}, timeout, interval).Should(BeTrue())
+
 			// Delete
 			Expect(k8sClient.Delete(context.Background(), group)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), groupUpdate)).Should(Succeed())
 
 			By("Expecting to delete successfully")
 			Eventually(func() error {


### PR DESCRIPTION
We'll be able to tell the controller where the group resource is, it
could be in a separate namespace

This was based on an implementation from the cassandra operator seen
here: https://github.com/k8ssandra/cass-operator/blob/master/controllers/control/cassandratask_controller.go#L135-L138

This fixes #21.