### PR TITLE
build(): Upgrade golang, operator-sdk, checkly-go-sdk

### DIFF
--- a/.github/workflows/main-merge.yaml
+++ b/.github/workflows/main-merge.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Start kind cluster
         uses: helm/kind-action@v1.2.0

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       # We need kind to test the code
       - name: Start kind cluster

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We support reading configuration from ingress resources, take a look at the [sam
 ## Versions
 
 We're using the following versions of packages:
-* operator-sdk 1.22.0
+* operator-sdk 1.22.2
 * golang 1.18
 
 ### direnv

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We support reading configuration from ingress resources, take a look at the [sam
 
 We're using the following versions of packages:
 * operator-sdk 1.22.2
-* golang 1.18
+* golang 1.19
 
 ### direnv
 

--- a/apis/checkly/v1alpha1/groupversion_info.go
+++ b/apis/checkly/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the checkly v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=k8s.checklyhq.com
+// +kubebuilder:object:generate=true
+// +groupName=k8s.checklyhq.com
 package v1alpha1
 
 import (

--- a/controllers/checkly/group_controller_test.go
+++ b/controllers/checkly/group_controller_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/checkly/checkly-go-sdk v1.5.7
+	github.com/checkly/checkly-go-sdk v1.6.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/checkly/checkly-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cb
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/checkly/checkly-go-sdk v1.5.7 h1:EbXM9etOWQ8Wu3iN93qXsQKI4fyIUI94PdSfonRcjQo=
 github.com/checkly/checkly-go-sdk v1.5.7/go.mod h1:wkAoXD2cVCNQEXi9lHZqy/zONIAZc5D9frih6Gas3Rs=
+github.com/checkly/checkly-go-sdk v1.6.1 h1:R504wAr5hjqYCnEiU25UOW9v5l7N9cMF6izbmg36uA4=
+github.com/checkly/checkly-go-sdk v1.6.1/go.mod h1:a1I5B287Fd06TL1C+V/9szb3ZU4+0Di100Zn8h+CDgg=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=


### PR DESCRIPTION
* golang v1.19
* operator-sdk: v1.22.2
* checkly-go-sdk: v1.6.1